### PR TITLE
Fixed bug in cannot? helper. Needs args.

### DIFF
--- a/lib/active_model_serializers/cancan/helpers.rb
+++ b/lib/active_model_serializers/cancan/helpers.rb
@@ -10,7 +10,7 @@ module ActiveModel
           current_ability.can? *args
         end
 
-        def cannot?
+        def cannot?(*args)
           current_ability.cannot? *args
         end
       end

--- a/spec/active_model_serializers/cancan/abilities_spec.rb
+++ b/spec/active_model_serializers/cancan/abilities_spec.rb
@@ -16,7 +16,7 @@ describe ActiveModel::Serializer::CanCan::Abilities do
     let(:serializer) do
       Class.new(ActiveModel::Serializer) do
         attributes :id
-        abilities :restful, :foo
+        abilities :restful, :foo, :bar
         def current_ability
           MockAbility.new(nil)
         end
@@ -24,6 +24,10 @@ describe ActiveModel::Serializer::CanCan::Abilities do
         def can_foo?
           true
         end
+
+        def can_bar?
+          cannot? :read, Category
+        end        
       end
     end
 
@@ -40,6 +44,7 @@ describe ActiveModel::Serializer::CanCan::Abilities do
       its([:update]) { should be_true }
       its([:show]) { should be_false }
       its([:foo]) { should be_true }
+      its([:bar]) { should be_true }
     end
   end
 end


### PR DESCRIPTION
Submitted this back to the old cancan gem last year, but it seems to have been abandoned.  Since we're moving to the new cancancan, resubmitting this PR here.
