### PR TITLE
Fix reflection

### DIFF
--- a/lib/active_model_serializers/cancan/reflection_value.rb
+++ b/lib/active_model_serializers/cancan/reflection_value.rb
@@ -7,7 +7,7 @@ module ActiveModel
           unless authorize?
             return val
           end
-          if val.kind_of?(Array)
+          if val.kind_of?(ActiveRecord::Associations::CollectionProxy)
             val.select do |item|
               serializer.current_ability.can?(:read, item)
             end


### PR DESCRIPTION
the serizlizer returns active_model associations and its class is *ModelName*::ActiveRecord_Associations_CollectionProxy when has_many
It may be a subclass of ActiveRecord::Associations::CollectionProxy < Relation < Object, not subclass of Array
so, at least on my environment, val.kind_of?(Array) returns false

Is it a bug?
sorry, I have less confidence 'cause I can't understand why existing codes passes the specs
I want you to investigate